### PR TITLE
[0.1.0] (ZH-28) BuildProperties bean을 런타임에서 사용할 수 있도록 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,11 @@ FROM gradle:8.14.3-jdk21-alpine AS builder
 
 WORKDIR /application
 
-COPY gradle gradle
-COPY build.gradle.kts gradlew ./
-RUN ./gradlew dependencies --no-daemon --quiet
+COPY build.gradle.kts ./
+RUN gradle dependencies --no-daemon --quiet
 
 COPY src src
-RUN ./gradlew bootJar -x test --no-daemon --quiet \
+RUN gradle bootJar -x test --no-daemon --quiet \
     && java -Djarmode=layertools -jar build/libs/*.jar extract
 
 ########################

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,10 @@ configurations {
     }
 }
 
+springBoot {
+    buildInfo()
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
### 📌 Task Details
- [x] BuildProperties Bean이 개발 환경(gradle 조절 내)에서만 받을 수 있어, 빌드 후 해당 빈을 찾을 수 없어 런타임 오류가 발생하던 이슈 해결

---

### 💬 Review Requirements (Optional)
dockerfile에서 굳이 내장 gradlew를 쓸 이유가 없는 것 같아 같이 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Application now embeds build metadata, enabling display of version and build details in diagnostics/endpoints.

- Chores
  - Docker image build updated to use the system Gradle during build.
  - Build process remains unchanged at runtime.
  - Potentially faster, quieter builds with no impact on application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->